### PR TITLE
New feature: Trim sandboxes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,9 @@ inputs:
   gitRepositoryUrl:
     description: 'Git Repository Url'
     required: false
+  trim_to_size:
+    description: 'The number of sandboxes to keep when a trim_to_size action is selected'
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/inputs.d.ts
+++ b/dist/inputs.d.ts
@@ -7,7 +7,8 @@ export declare enum Actions {
     RemoveSandbox = "removeSandbox",
     ValidateVeracodeApiCreds = "validateVeracodeApiCreds",
     ValidatePolicyName = "validatePolicyName",
-    registerBuild = "registerBuild"
+    registerBuild = "registerBuild",
+    trimSandboxes = "trim-sandboxes"
 }
 export type Inputs = {
     action: Actions;
@@ -36,10 +37,12 @@ export type Inputs = {
     pipeline_scan_flaw_filter: string;
     filtered_results_file: string;
     gitRepositoryUrl: string;
+    trim_to_size: number;
 };
 export declare const parseInputs: (getInput: GetInput) => Inputs;
 export declare const vaildateScanResultsActionInput: (inputs: Inputs) => boolean;
 export declare const vaildateRemoveSandboxInput: (inputs: Inputs) => boolean;
+export declare const vaildateApplicationProfileInput: (inputs: Inputs) => boolean;
 export declare const ValidatePolicyName: (inputs: Inputs) => boolean;
 export declare const ValidateVeracodeApiCreds: (inputs: Inputs) => boolean;
 export {};

--- a/dist/namespaces/VeracodeApplication.d.ts
+++ b/dist/namespaces/VeracodeApplication.d.ts
@@ -32,6 +32,7 @@ export interface SandboxResultsData {
 export interface Sandbox {
     guid: string;
     name: string;
+    modified: string;
 }
 export interface SelfUserResultsData {
     api_credentials: {

--- a/dist/services/application-service.d.ts
+++ b/dist/services/application-service.d.ts
@@ -5,3 +5,4 @@ export declare function removeSandbox(inputs: Inputs): Promise<void>;
 export declare function validateVeracodeApiCreds(inputs: Inputs): Promise<string | void>;
 export declare function validatePolicyName(inputs: Inputs): Promise<void>;
 export declare function registerBuild(inputs: Inputs): Promise<void>;
+export declare function trimSandboxesFromApplicationProfile(inputs: Inputs): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@actions/artifact": "^2.1.11",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.11.3",
+    "@types/node": "^20.19.10",
     "@types/sjcl": "^1.0.34",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -9,7 +9,8 @@ export enum Actions {
   RemoveSandbox = 'removeSandbox',
   ValidateVeracodeApiCreds = 'validateVeracodeApiCreds',
   ValidatePolicyName = 'validatePolicyName',
-  registerBuild = 'registerBuild'
+  registerBuild = 'registerBuild',
+  trimSandboxes = 'trim-sandboxes'
 }
 
 export type Inputs = {
@@ -39,6 +40,7 @@ export type Inputs = {
   pipeline_scan_flaw_filter: string;
   filtered_results_file: string;
   gitRepositoryUrl: string;
+  trim_to_size: number;
 };
 
 export const parseInputs = (getInput: GetInput): Inputs => {
@@ -82,6 +84,7 @@ export const parseInputs = (getInput: GetInput): Inputs => {
 
   const filtered_results_file = getInput('filtered_results_file');
   const gitRepositoryUrl = getInput('gitRepositoryUrl');
+  const trim_to_size = getInput('trim_to_size');
 
   if (source_repository && source_repository.split('/').length !== 2) {
     throw new Error('source_repository needs to be in the {owner}/{repo} format');
@@ -93,7 +96,7 @@ export const parseInputs = (getInput: GetInput): Inputs => {
     policyname, path, start_line: +start_line, end_line: +end_line, break_build_invalid_policy,
     filter_mitigated_flaws, check_run_name, head_sha, branch, event_type, issue_trigger_flow,
     workflow_app, line_number_slop: +line_number_slop, pipeline_scan_flaw_filter, filtered_results_file,
-    gitRepositoryUrl
+    gitRepositoryUrl,trim_to_size: +trim_to_size
   };
 };
 
@@ -108,6 +111,14 @@ export const vaildateScanResultsActionInput = (inputs: Inputs): boolean => {
 export const vaildateRemoveSandboxInput = (inputs: Inputs): boolean => {
   console.log(inputs);
   if (!inputs.sandboxname) {
+    return false;
+  }
+  return true;
+}
+
+export const vaildateApplicationProfileInput = (inputs: Inputs): boolean => {
+  console.log(inputs);
+  if (!inputs.appname) {
     return false;
   }
   return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,12 @@ export async function run(): Promise<void> {
     case 'registerBuild':
       await applicationService.registerBuild(inputs);
       break;
+    case 'trim-sandboxes':
+      await applicationService.trimSandboxesFromApplicationProfile(inputs);
+      break;
     default:
       core.setFailed(
-        `Invalid action: ${inputs.action}. Allowed actions are: getPolicyNameByProfileName, preparePipelineResults, preparePolicyResults, removeSandbox, validateVeracodeApiCreds, validatePolicyName, registerBuild.`,
+        `Invalid action: ${inputs.action}. Allowed actions are: getPolicyNameByProfileName, preparePipelineResults, preparePolicyResults, removeSandbox, validateVeracodeApiCreds, validatePolicyName, registerBuild, and trim-sandboxes.`,
       );
   }
 }

--- a/src/namespaces/VeracodeApplication.ts
+++ b/src/namespaces/VeracodeApplication.ts
@@ -37,6 +37,7 @@ export interface SandboxResultsData {
 export interface Sandbox {
   guid: string;
   name: string;
+  modified: string;
 }
 
 export interface SelfUserResultsData {

--- a/src/services/application-service.ts
+++ b/src/services/application-service.ts
@@ -5,7 +5,7 @@ import * as Checks from '../namespaces/Checks';
 import { updateChecks } from './check-service';
 import * as VeracodeApplication from '../namespaces/VeracodeApplication';
 import * as http from '../api/http-request';
-import { Inputs, vaildateRemoveSandboxInput } from '../inputs';
+import { Inputs, vaildateApplicationProfileInput, vaildateRemoveSandboxInput } from '../inputs';
 import * as fs from 'fs/promises';
 import { DefaultArtifactClient } from '@actions/artifact';
 
@@ -37,14 +37,13 @@ export async function getApplicationByName(
   }
 }
 
-export async function removeSandbox(inputs: Inputs): Promise<void> {
-  if(!vaildateRemoveSandboxInput(inputs)) {
-    core.setFailed('sandboxname is required.');
+async function getAppGUIDByAppName(inputs: Inputs) : Promise<any> {
+  if(!vaildateApplicationProfileInput(inputs)) {
+    core.setFailed('Application Profile name is required.');
   }
   const appname = inputs.appname;
   const vid = inputs.vid;
   const vkey = inputs.vkey;
-  const sandboxName = inputs.sandboxname;
 
   let application:VeracodeApplication.Application;
 
@@ -56,6 +55,21 @@ export async function removeSandbox(inputs: Inputs): Promise<void> {
   }
 
   const appGuid = application.guid;
+
+  return appGuid;
+}
+
+export async function removeSandbox(inputs: Inputs): Promise<void> {
+  if(!vaildateRemoveSandboxInput(inputs)) {
+    core.setFailed('sandboxname is required.');
+  }
+
+  const appGuid = await getAppGUIDByAppName(inputs);
+
+  const appname = inputs.appname;
+  const vid = inputs.vid;
+  const vkey = inputs.vkey;
+  const sandboxName = inputs.sandboxname;
 
   let sandboxes: VeracodeApplication.Sandbox[];
   try {
@@ -154,7 +168,7 @@ export async function validateVeracodeApiCreds(inputs: Inputs): Promise<string |
       await http.getResourceByAttribute<VeracodeApplication.SelfUserResultsData>(inputs.vid, inputs.vkey, getSelfUserDetailsResource);
 
     if (applicationResponse && applicationResponse?.api_credentials?.expiration_ts) {
-      core.info(`VERACODE_API_ID and VERACODE_API_KEY is valid, Credentials expiration date - ${applicationResponse.api_credentials.expiration_ts}`);
+      core.info(`VERACODE_API_ID and VERACODE_API_KEY is valid, Credentials expiration date - ${JSON.stringify(applicationResponse.api_credentials.expiration_ts)}`);
     } else {
       core.setFailed('Invalid/Expired VERACODE_API_ID and VERACODE_API_KEY');
       annotations.push({
@@ -303,4 +317,70 @@ export async function registerBuild(inputs: Inputs): Promise<void> {
   } catch (error) {
     core.info(`Error while creating the ${artifactName} artifact ${error}`);
   }
+}
+
+export async function trimSandboxesFromApplicationProfile(inputs: Inputs): Promise<void> {
+
+  const appGuid = await getAppGUIDByAppName(inputs);
+
+  const appname = inputs.appname;
+  const vid = inputs.vid;
+  const vkey = inputs.vkey;
+  const sandboxName = inputs.sandboxname;
+
+  let sandboxes: VeracodeApplication.Sandbox[];
+  try {
+    sandboxes = await getSandboxesByApplicationGuid(appGuid, vid, vkey);
+  } catch (error) {
+    throw new Error(`Error retrieving sandboxes for application ${appname}`);
+  }
+
+  // Sort sandboxes by their modified field => which is the last scan time
+  let sortedSandboxes = sandboxes.sort((sandboxA,sandboxB) => {
+            let retVal = sandboxA.modified > sandboxB.modified ;
+            return (retVal ? 1 : -1);
+        });
+
+  if (core.isDebug()) {
+    core.info('Date match Sandboxes from oldest to newest:');
+    core.info('===========================================');
+    sortedSandboxes.forEach((sandbox,i) => {
+        core.info(`[${i}] - ${sandbox.name} => ${sandbox.modified}`);
+    });
+    core.info('-------------------------------------------');
+  }
+
+  const total_sb_size = sortedSandboxes.length;
+  const keep_size = inputs.trim_to_size;
+  let sandboxesToDelete = [];
+
+  if (keep_size>=total_sb_size){
+    // Nothing to delete
+    core.info(`Total sandboxes [${total_sb_size}] are equal or less than the trim_to_size input [${keep_size}]. Nothing to delete`);
+    return;
+  } else {
+    const number_to_delete = total_sb_size-keep_size;
+    sandboxesToDelete = sortedSandboxes.slice(0,number_to_delete);
+  }
+
+  core.info('Starting to delete sandboxes');
+  const deletedSandboxNames: string[] = [];
+  await Promise.all(sandboxesToDelete.map(async (sandbox,i) => {
+      core.info(`[${i}] - ${sandbox.name} => ${sandbox.modified}, ${sandbox.guid}`);
+      const removeSandboxResource = {
+        resourceUri: appConfig.api.veracode.sandboxUri.replace('${appGuid}', appGuid),
+        resourceId: sandbox.guid,
+      };
+      try {
+        await http.deleteResourceById(vid, vkey, removeSandboxResource);
+        core.info(`Sandbox '${sandbox.name}' with GUID [${sandbox.guid}] deleted`);
+        deletedSandboxNames.push(`'${sandbox.name}' (GUID:${sandbox.guid})`);
+      } catch (error) {
+        core.warning(`Error removing sandbox:${error}`);
+        core.setFailed(`Error removing sandbox ${sandbox.name}`);
+      }
+  }));
+
+  core.info(`Deleted Sandboxes names: ${JSON.stringify(deletedSandboxNames)}`);
+  core.info('---------------------------------');
 }

--- a/src/services/pipeline-results-service.ts
+++ b/src/services/pipeline-results-service.ts
@@ -291,7 +291,7 @@ export async function preparePipelineResults(inputs: Inputs): Promise<void> {
   }
 
   // What if no policy scan?
-  core.info(`Policy findings: ${policyFindings.length}`);
+  core.info(`Policy findings: ${JSON.stringify(policyFindings.length)}`);
 
   const filter_mitigated_flaws = inputs.filter_mitigated_flaws;
   let policyFindingsToExlcude: VeracodePolicyResult.Finding[] = [];
@@ -314,7 +314,7 @@ export async function preparePipelineResults(inputs: Inputs): Promise<void> {
     });
   }
 
-  core.info(`Mitigated policy findings: ${policyFindingsToExlcude.length}`);
+  core.info(`Mitigated policy findings: ${JSON.stringify(policyFindingsToExlcude.length)}`);
 
   // Remove item in findingsArray if there are item in policyFindingsToExlcude if the file_path and
   // cwe_id and line_number are the same


### PR DESCRIPTION
The pull request is to add a new option to the helper set of activities.

The new action is: **trim-sandboxes**, which takes the following attributes:
- appname: '<Application Name>'
- action: trim-sandboxes
# The number of sandboxes to keep
- trim_to_size: 4 
# credentials for the APIs
vid: ${{ secrets.VERACODE_API_ID }}
vkey: ${{ secrets.VERACODE_API_KEY }}

The action will remove sandboxes from the oldest modified date based on the trim_to_size number