### PR TITLE
Fix exact app name at filter on mitigation

### DIFF
--- a/src/services/application-service.ts
+++ b/src/services/application-service.ts
@@ -28,9 +28,18 @@ export async function getApplicationByName(
     if (applications.length === 0) {
       throw new Error(`No application found with name ${appname}`);
     } else if (applications.length > 1) {
-      core.info(`Multiple applications found with name ${appname}, selecting the first found`);
+      core.info(`Multiple applications found starting with ${JSON.stringify(appname)}`);
+      const filteredApplications = applications.filter(app => app.profile?.name === appname);
+      if (filteredApplications.length === 0) {
+        core.warning(`No application found with exact name ${JSON.stringify(appname)}. Returning the first application from the list in the original API query.`);
+        return applications[0];
+      } else if (filteredApplications.length > 1) {
+        core.warning(`Multiple applications (${filteredApplications.length}) found with exact name ${JSON.stringify(appname)}. Returning the first application from the filtered list.`);  
+      } else {
+        core.info(`One application found with exact name ${JSON.stringify(appname)}. While there were ${JSON.stringify(applications.length)} applications starting with ${JSON.stringify(appname)}.`);
+      }
+      return filteredApplications[0];
     }
-
     return applications[0];
   } catch (error) {
     throw error;
@@ -345,7 +354,7 @@ export async function trimSandboxesFromApplicationProfile(inputs: Inputs): Promi
     core.info('Date match Sandboxes from oldest to newest:');
     core.info('===========================================');
     sortedSandboxes.forEach((sandbox,i) => {
-        core.info(`[${i}] - ${sandbox.name} => ${sandbox.modified}`);
+        core.info(`[${i}] - ${JSON.stringify(sandbox.name)} => ${sandbox.modified}`);
     });
     core.info('-------------------------------------------');
   }
@@ -356,7 +365,7 @@ export async function trimSandboxesFromApplicationProfile(inputs: Inputs): Promi
 
   if (keep_size>=total_sb_size){
     // Nothing to delete
-    core.info(`Total sandboxes [${total_sb_size}] are equal or less than the trim_to_size input [${keep_size}]. Nothing to delete`);
+    core.info(`Total sandboxes [${total_sb_size}] are equal or less than the trim_to_size input [${JSON.stringify(keep_size)}]. Nothing to delete`);
     return;
   } else {
     const number_to_delete = total_sb_size-keep_size;
@@ -366,14 +375,14 @@ export async function trimSandboxesFromApplicationProfile(inputs: Inputs): Promi
   core.info('Starting to delete sandboxes');
   const deletedSandboxNames: string[] = [];
   await Promise.all(sandboxesToDelete.map(async (sandbox,i) => {
-      core.info(`[${i}] - ${sandbox.name} => ${sandbox.modified}, ${sandbox.guid}`);
+    core.info(`[${i}] - ${JSON.stringify(sandbox.name)} => ${sandbox.modified}, ${sandbox.guid}`);
       const removeSandboxResource = {
         resourceUri: appConfig.api.veracode.sandboxUri.replace('${appGuid}', appGuid),
         resourceId: sandbox.guid,
       };
       try {
         await http.deleteResourceById(vid, vkey, removeSandboxResource);
-        core.info(`Sandbox '${sandbox.name}' with GUID [${sandbox.guid}] deleted`);
+        core.info(`Sandbox '${JSON.stringify(sandbox.name)}' with GUID [${JSON.stringify(sandbox.guid)}] deleted`);
         deletedSandboxNames.push(`'${sandbox.name}' (GUID:${sandbox.guid})`);
       } catch (error) {
         core.warning(`Error removing sandbox:${error}`);

--- a/src/services/application-service.ts
+++ b/src/services/application-service.ts
@@ -27,16 +27,19 @@ export async function getApplicationByName(
     const applications = applicationResponse._embedded?.applications || [];
     if (applications.length === 0) {
       throw new Error(`No application found with name ${appname}`);
-    } else if (applications.length > 1) {
-      core.info(`Multiple applications found starting with ${JSON.stringify(appname)}`);
+    } else if (applications.length >= 1) {
       const filteredApplications = applications.filter(app => app.profile?.name === appname);
       if (filteredApplications.length === 0) {
         core.warning(`No application found with exact name ${JSON.stringify(appname)}. Returning the first application from the list in the original API query.`);
         return applications[0];
       } else if (filteredApplications.length > 1) {
         core.warning(`Multiple applications (${filteredApplications.length}) found with exact name ${JSON.stringify(appname)}. Returning the first application from the filtered list.`);  
-      } else {
-        core.info(`One application found with exact name ${JSON.stringify(appname)}. While there were ${JSON.stringify(applications.length)} applications starting with ${JSON.stringify(appname)}.`);
+      } else { // filteredApplications.length === 1
+        if (applications.length > 1) {
+          core.info(`One application found with exact name ${JSON.stringify(appname)}. While there were ${JSON.stringify(applications.length)} applications starting with ${JSON.stringify(appname)}.`);
+        } else {
+          core.info(`One application found with exact name ${JSON.stringify(appname)}.`);
+        }
       }
       return filteredApplications[0];
     }

--- a/src/services/application-service.ts
+++ b/src/services/application-service.ts
@@ -25,25 +25,26 @@ export async function getApplicationByName(
       await http.getResourceByAttribute<VeracodeApplication.ResultsData>(vid, vkey, getApplicationByNameResource);
 
     const applications = applicationResponse._embedded?.applications || [];
-    if (applications.length === 0) {
+    if (applications.length === 0) { // no application with the given name was found
+      core.warning(`No application found with name ${appname}`);
       throw new Error(`No application found with name ${appname}`);
-    } else if (applications.length >= 1) {
-      const filteredApplications = applications.filter(app => app.profile?.name === appname);
-      if (filteredApplications.length === 0) {
-        core.warning(`No application found with exact name ${JSON.stringify(appname)}. Returning the first application from the list in the original API query.`);
-        return applications[0];
-      } else if (filteredApplications.length > 1) {
-        core.warning(`Multiple applications (${filteredApplications.length}) found with exact name ${JSON.stringify(appname)}. Returning the first application from the filtered list.`);  
-      } else { // filteredApplications.length === 1
-        if (applications.length > 1) {
-          core.info(`One application found with exact name ${JSON.stringify(appname)}. While there were ${JSON.stringify(applications.length)} applications starting with ${JSON.stringify(appname)}.`);
-        } else {
-          core.info(`One application found with exact name ${JSON.stringify(appname)}.`);
-        }
+    } 
+    
+    const filteredApplications = applications.filter(app => app.profile?.name === appname);
+    if (filteredApplications.length === 0) { // no application with the exact given name was found
+      core.warning(`No application found with exact name ${JSON.stringify(appname)}. Returning the first application from the list in the original API query.`);
+      return applications[0];
+    } else if (filteredApplications.length > 1) {
+      core.warning(`Multiple applications (${filteredApplications.length}) found with exact name ${JSON.stringify(appname)}. Returning the first application from the filtered list.`);  
+    } else { // exactly one application with the exact given name was found
+      if (applications.length > 1) {
+        core.info(`One application found with exact name ${JSON.stringify(appname)}. While there were ${JSON.stringify(applications.length)} applications starting with ${JSON.stringify(appname)}.`);
+      } else {
+        core.info(`One application found with exact name ${JSON.stringify(appname)}.`);
       }
-      return filteredApplications[0];
     }
-    return applications[0];
+    return filteredApplications[0];
+    
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
Hi,

The change is in a single file, which focuses on a single function that pulls an application by name. The API respond with "startswith" instead of "equals". That results in an unintended outcome for some scenarios.

The change tests for the exact name of the application, and if there are others, it will output the number of profiles that start with the same name.

The fix was tested in this repository: 
- https://github.com/lerer-veracode/vulnerable-express-api - 2 findings, one medium, and one Very High

And it was tested using the platform profiles:
- vul-express:  https://analysiscenter.veracode.com/auth/index.jsp#HomeAppProfile:108655:2745204 - 1 out of 2 is mitigated
- vul-express-second:  https://analysiscenter.veracode.com/auth/index.jsp#HomeAppProfile:108655:2745213 - no mitigations